### PR TITLE
Implement tuple_as on zero-length tuples

### DIFF
--- a/code_gen/src/code_gen.rs
+++ b/code_gen/src/code_gen.rs
@@ -111,7 +111,7 @@ fn gen_tuple_n_impl_size(ctx: &Ctx, size: usize, item_names: &[Ident]) -> TokenS
 }
 
 fn gen_tuple_as(ctx: &Ctx, out_dir: &Path) {
-    let items = (2..33usize).map(|i| gen_tuple_as_size(ctx, i));
+    let items = (0..33usize).map(|i| gen_tuple_as_size(ctx, i));
     let tks = quote! { #(#items)* };
     let mut code = tks.to_string();
     code.insert_str(0, "// This file is by code gen, do not modify\n\n");
@@ -127,61 +127,61 @@ fn gen_tuple_as_size(ctx: &Ctx, size: usize) -> TokenStream {
     let mut_doc = format!("AsMut for Tuple{}", size);
 
     let tks = quote! {
-        impl<'a, #(#nts: 'a),*> TupleAsRef<'a> for (#(#nts),*) {
-            type OutTuple = (#(&'a #nts),*);
+        impl<'a, #(#nts: 'a,)*> TupleAsRef<'a> for (#(#nts,)*) {
+            type OutTuple = (#(&'a #nts,)*);
 
             #[doc = #ref_doc]
             fn as_ref(&'a self) -> Self::OutTuple {
-                (#(&self.#size_lits),*)
+                (#(&self.#size_lits,)*)
             }
         }
 
-        impl<'a, #(#nts: 'a),*> TupleAsMut<'a> for (#(#nts),*) {
-            type OutTuple = (#(&'a mut #nts),*);
+        impl<'a, #(#nts: 'a,)*> TupleAsMut<'a> for (#(#nts,)*) {
+            type OutTuple = (#(&'a mut #nts,)*);
 
             #[doc = #mut_doc]
             fn as_mut(&'a mut self) -> Self::OutTuple {
-                (#(&mut self.#size_lits),*)
+                (#(&mut self.#size_lits,)*)
             }
         }
 
-        impl<#(#nts),*> TupleAsOption for (#(#nts),*) {
-            type OutTuple = (#(Option<#nts>),*);
+        impl<#(#nts,)*> TupleAsOption for (#(#nts,)*) {
+            type OutTuple = (#(Option<#nts>,)*);
 
             fn as_some(self) -> Self::OutTuple {
-                (#(Some(self.#size_lits)),*)
+                (#(Some(self.#size_lits),)*)
             }
         }
 
-        impl<E, #(#nts),*> TupleAsResultOk<E> for (#(#nts),*) {
-            type OutTuple = (#(Result<#nts, E>),*);
+        impl<E, #(#nts,)*> TupleAsResultOk<E> for (#(#nts,)*) {
+            type OutTuple = (#(Result<#nts, E>,)*);
 
             fn as_ok(self) -> Self::OutTuple {
-                (#(Ok(self.#size_lits)),*)
+                (#(Ok(self.#size_lits),)*)
             }
         }
 
-        impl<O, #(#nts),*> TupleAsResultErr<O> for (#(#nts),*) {
-            type OutTuple = (#(Result<O, #nts>),*);
+        impl<O, #(#nts,)*> TupleAsResultErr<O> for (#(#nts,)*) {
+            type OutTuple = (#(Result<O, #nts>,)*);
 
             fn as_err(self) -> Self::OutTuple {
-                (#(Err(self.#size_lits)),*)
+                (#(Err(self.#size_lits),)*)
             }
         }
 
-        impl<'a, #(#nts: 'a + Deref),*> TupleAsDeref<'a> for (#(#nts),*) {
-            type OutTuple = (#(&'a <#nts as Deref>::Target),*);
+        impl<'a, #(#nts: 'a + Deref,)*> TupleAsDeref<'a> for (#(#nts,)*) {
+            type OutTuple = (#(&'a <#nts as Deref>::Target,)*);
 
             fn as_deref(&'a self) -> Self::OutTuple {
-                (#(self.#size_lits.deref()),*)
+                (#(self.#size_lits.deref(),)*)
             }
         }
 
-        impl<'a, #(#nts: 'a + DerefMut),*> TupleAsDerefMut<'a> for (#(#nts),*) {
-            type OutTuple = (#(&'a mut <#nts as Deref>::Target),*);
+        impl<'a, #(#nts: 'a + DerefMut,)*> TupleAsDerefMut<'a> for (#(#nts,)*) {
+            type OutTuple = (#(&'a mut <#nts as Deref>::Target,)*);
 
             fn as_deref_mut(&'a mut self) -> Self::OutTuple {
-                (#(self.#size_lits.deref_mut()),*)
+                (#(self.#size_lits.deref_mut(),)*)
             }
         }
     };

--- a/tuples/src/gen/tuple_as.rs
+++ b/tuples/src/gen/tuple_as.rs
@@ -1,5 +1,93 @@
 // This file is by code gen, do not modify
 
+impl<'a> TupleAsRef<'a> for () {
+    type OutTuple = ();
+    #[doc = "AsRef for Tuple0"]
+    fn as_ref(&'a self) -> Self::OutTuple {
+        ()
+    }
+}
+impl<'a> TupleAsMut<'a> for () {
+    type OutTuple = ();
+    #[doc = "AsMut for Tuple0"]
+    fn as_mut(&'a mut self) -> Self::OutTuple {
+        ()
+    }
+}
+impl TupleAsOption for () {
+    type OutTuple = ();
+    fn as_some(self) -> Self::OutTuple {
+        ()
+    }
+}
+impl<E> TupleAsResultOk<E> for () {
+    type OutTuple = ();
+    fn as_ok(self) -> Self::OutTuple {
+        ()
+    }
+}
+impl<O> TupleAsResultErr<O> for () {
+    type OutTuple = ();
+    fn as_err(self) -> Self::OutTuple {
+        ()
+    }
+}
+impl<'a> TupleAsDeref<'a> for () {
+    type OutTuple = ();
+    fn as_deref(&'a self) -> Self::OutTuple {
+        ()
+    }
+}
+impl<'a> TupleAsDerefMut<'a> for () {
+    type OutTuple = ();
+    fn as_deref_mut(&'a mut self) -> Self::OutTuple {
+        ()
+    }
+}
+impl<'a, T0: 'a> TupleAsRef<'a> for (T0,) {
+    type OutTuple = (&'a T0,);
+    #[doc = "AsRef for Tuple1"]
+    fn as_ref(&'a self) -> Self::OutTuple {
+        (&self.0,)
+    }
+}
+impl<'a, T0: 'a> TupleAsMut<'a> for (T0,) {
+    type OutTuple = (&'a mut T0,);
+    #[doc = "AsMut for Tuple1"]
+    fn as_mut(&'a mut self) -> Self::OutTuple {
+        (&mut self.0,)
+    }
+}
+impl<T0> TupleAsOption for (T0,) {
+    type OutTuple = (Option<T0>,);
+    fn as_some(self) -> Self::OutTuple {
+        (Some(self.0),)
+    }
+}
+impl<E, T0> TupleAsResultOk<E> for (T0,) {
+    type OutTuple = (Result<T0, E>,);
+    fn as_ok(self) -> Self::OutTuple {
+        (Ok(self.0),)
+    }
+}
+impl<O, T0> TupleAsResultErr<O> for (T0,) {
+    type OutTuple = (Result<O, T0>,);
+    fn as_err(self) -> Self::OutTuple {
+        (Err(self.0),)
+    }
+}
+impl<'a, T0: 'a + Deref> TupleAsDeref<'a> for (T0,) {
+    type OutTuple = (&'a <T0 as Deref>::Target,);
+    fn as_deref(&'a self) -> Self::OutTuple {
+        (self.0.deref(),)
+    }
+}
+impl<'a, T0: 'a + DerefMut> TupleAsDerefMut<'a> for (T0,) {
+    type OutTuple = (&'a mut <T0 as Deref>::Target,);
+    fn as_deref_mut(&'a mut self) -> Self::OutTuple {
+        (self.0.deref_mut(),)
+    }
+}
 impl<'a, T0: 'a, T1: 'a> TupleAsRef<'a> for (T0, T1) {
     type OutTuple = (&'a T0, &'a T1);
     #[doc = "AsRef for Tuple2"]

--- a/tuples/src/tuple_as.rs
+++ b/tuples/src/tuple_as.rs
@@ -12,14 +12,6 @@ pub trait TupleAsRef<'a> {
     fn as_ref(&'a self) -> Self::OutTuple;
 }
 
-impl<'a, T: 'a> TupleAsRef<'a> for (T,) {
-    type OutTuple = (&'a T,);
-
-    fn as_ref(&'a self) -> Self::OutTuple {
-        (&self.0,)
-    }
-}
-
 /// AsMut for Tuple
 pub trait TupleAsMut<'a> {
     type OutTuple: 'a;
@@ -28,28 +20,12 @@ pub trait TupleAsMut<'a> {
     fn as_mut(&'a mut self) -> Self::OutTuple;
 }
 
-impl<'a, T: 'a> TupleAsMut<'a> for (T,) {
-    type OutTuple = (&'a mut T,);
-
-    fn as_mut(&'a mut self) -> Self::OutTuple {
-        (&mut self.0,)
-    }
-}
-
 /// Mapping item to `Option` for Tuple
 pub trait TupleAsOption {
     type OutTuple;
 
     /// Mapping item to `Option::Some` for Tuple
     fn as_some(self) -> Self::OutTuple;
-}
-
-impl<T> TupleAsOption for (T,) {
-    type OutTuple = (Option<T>,);
-
-    fn as_some(self) -> Self::OutTuple {
-        (Some(self.0),)
-    }
 }
 
 /// Mapping item to `Result` for Tuple
@@ -68,22 +44,6 @@ pub trait TupleAsResultErr<T> {
     fn as_err(self) -> Self::OutTuple;
 }
 
-impl<T, E> TupleAsResultOk<E> for (T,) {
-    type OutTuple = (Result<T, E>,);
-
-    fn as_ok(self) -> Self::OutTuple {
-        (Ok(self.0),)
-    }
-}
-
-impl<T, O> TupleAsResultErr<O> for (T,) {
-    type OutTuple = (Result<O, T>,);
-
-    fn as_err(self) -> Self::OutTuple {
-        (Err(self.0),)
-    }
-}
-
 /// AsDeref for Tuple
 pub trait TupleAsDeref<'a> {
     type OutTuple: 'a;
@@ -92,26 +52,10 @@ pub trait TupleAsDeref<'a> {
     fn as_deref(&'a self) -> Self::OutTuple;
 }
 
-impl<'a, T: 'a + Deref> TupleAsDeref<'a> for (T,) {
-    type OutTuple = (&'a <T as Deref>::Target,);
-
-    fn as_deref(&'a self) -> Self::OutTuple {
-        (self.0.deref(),)
-    }
-}
-
 /// AsDerefMut for Tuple
 pub trait TupleAsDerefMut<'a> {
     type OutTuple: 'a;
 
     /// AsDerefMut for Tuple
     fn as_deref_mut(&'a mut self) -> Self::OutTuple;
-}
-
-impl<'a, T: 'a + DerefMut> TupleAsDerefMut<'a> for (T,) {
-    type OutTuple = (&'a mut <T as Deref>::Target,);
-
-    fn as_deref_mut(&'a mut self) -> Self::OutTuple {
-        (self.0.deref_mut(),)
-    }
 }


### PR DESCRIPTION
Resolves #6.

I modified the generation code to start at `0` instead of `2` and to always put a `,` after a type name or value, which generates valid code for 1-tuples.

These changes meant I could also delete the manual implementations for 1-tuples, since valid code is generated now.